### PR TITLE
Change: Avoid crash with invalid date-time strings

### DIFF
--- a/src/Form/Type/Entity/DatumType.php
+++ b/src/Form/Type/Entity/DatumType.php
@@ -71,16 +71,25 @@ class DatumType extends AbstractType
                             'model_transformer' => new CallbackTransformer(
                                 function ($string): ?string {
                                     if (!empty($string)) {
-                                        return \DateTimeImmutable::createFromFormat('Y-m-d', $string)->format($this->security->getUser()->getDateFormat());
+										$stringParsed = \DateTimeImmutable::createFromFormat('Y-m-d', $string)->format($this->security->getUser()->getDateFormat());
+										if(!$stringParsed)
+										{
+											return null;
+										}
+										return $stringParsed;
                                     }
 
                                     return null;
                                 },
                                 function ($date): ?string {
                                     if (!empty($date)) {
-                                        return \DateTimeImmutable::createFromFormat($this->security->getUser()->getDateFormat(), $date)->format('Y-m-d');
+										$dateParsed = \DateTimeImmutable::createFromFormat($this->security->getUser()->getDateFormat(), $date)->format('Y-m-d');
+										if(!$dateParsed)
+										{
+											return null;
+										}
+										return $dateParsed;
                                     }
-
                                     return null;
                                 }
                             ),


### PR DESCRIPTION
https://github.com/benjaminjonard/koillection/issues/825
```
in[ src/Form/Type/Entity/DatumType.php ](file:///var/www/koillection/src/Form/Type/Entity/DatumType.php#L81)(line 81)

                                        return null;
                                    },
                                    function ($date): ?string {
                                        if (!empty($date)) {
                                            return \DateTimeImmutable::createFromFormat($this->security->getUser()->getDateFormat(), $date)->format('Y-m-d');
                                        }
                                        return null;
                                    }
                                ),

in[ vendor/symfony/form/CallbackTransformer.php ](file:///var/www/koillection/vendor/symfony/form/CallbackTransformer.php#L32)-> App\Form\Type\Entity\{closure} (line 32)
in[ vendor/symfony/form/Form.php ](file:///var/www/koillection/vendor/symfony/form/Form.php#L965)-> reverseTransform (line 965)
in[ vendor/symfony/form/Form.php ](file:///var/www/koillection/vendor/symfony/form/Form.php#L569)-> normToModel (line 569)
in[ vendor/symfony/form/Form.php ](file:///var/www/koillection/vendor/symfony/form/Form.php#L499)-> submit (line 499)
in[ vendor/symfony/form/Form.php ](file:///var/www/koillection/vendor/symfony/form/Form.php#L499)-> submit (line 499)
in[ vendor/symfony/form/Form.php ](file:///var/www/koillection/vendor/symfony/form/Form.php#L499)-> submit (line 499)
in[ vendor/symfony/form/Extension/HttpFoundation/HttpFoundationRequestHandler.php ](file:///var/www/koillection/vendor/symfony/form/Extension/HttpFoundation/HttpFoundationRequestHandler.php#L109)-> submit (line 109)
in[ vendor/symfony/form/Form.php ](file:///var/www/koillection/vendor/symfony/form/Form.php#L420)-> handleRequest (line 420)
Form->handleRequest() in[ src/Controller/ItemController.php ](file:///var/www/koillection/src/Controller/ItemController.php#L77)(line 77)
in[ vendor/symfony/http-kernel/HttpKernel.php ](file:///var/www/koillection/vendor/symfony/http-kernel/HttpKernel.php#L166)-> add (line 166)
in[ vendor/symfony/http-kernel/HttpKernel.php ](file:///var/www/koillection/vendor/symfony/http-kernel/HttpKernel.php#L74)-> handleRaw (line 74)
in[ vendor/symfony/http-kernel/Kernel.php ](file:///var/www/koillection/vendor/symfony/http-kernel/Kernel.php#L197)-> handle (line 197)
in[ vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php ](file:///var/www/koillection/vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php#L35)-> handle (line 35)
in[ vendor/autoload_runtime.php ](file:///var/www/koillection/vendor/autoload_runtime.php#L29)-> run (line 29)
require_once('/var/www/koillection/vendor/autoload_runtime.php') in[ public/index.php ](file:///var/www/koillection/public/index.php#L5)(line 5)
```

```
Error:
Call to a member function format() on bool

  at src/Form/Type/Entity/DatumType.php:81
  at App\Form\Type\Entity\DatumType->App\Form\Type\Entity\{closure}()
     (vendor/symfony/form/CallbackTransformer.php:32)
  at Symfony\Component\Form\CallbackTransformer->reverseTransform()
     (vendor/symfony/form/Form.php:965)
  at Symfony\Component\Form\Form->normToModel()
     (vendor/symfony/form/Form.php:569)
  at Symfony\Component\Form\Form->submit()
     (vendor/symfony/form/Form.php:499)
  at Symfony\Component\Form\Form->submit()
     (vendor/symfony/form/Form.php:499)
  at Symfony\Component\Form\Form->submit()
     (vendor/symfony/form/Form.php:499)
  at Symfony\Component\Form\Form->submit()
     (vendor/symfony/form/Extension/HttpFoundation/HttpFoundationRequestHandler.php:109)
  at Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler->handleRequest()
     (vendor/symfony/form/Form.php:420)
  at Symfony\Component\Form\Form->handleRequest()
     (src/Controller/ItemController.php:77)
  at App\Controller\ItemController->add()
     (vendor/symfony/http-kernel/HttpKernel.php:166)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
     (vendor/autoload_runtime.php:29)
  at require_once('/var/www/koillection/vendor/autoload_runtime.php')
     (public/index.php:5)                
```

If we tab into the textbox, and then edit the string in the textbox to be invalid, e.g. `2020/09/09`, Koillection still crashes out, as the string parser cannot handle dates formatted in anything bar the format it expects.

I *think* this should work to at least just discard the value if the datetime parse fails, but I'm not really a PHP person :)