### PR TITLE
Fix broken choicelist support in API

### DIFF
--- a/src/Entity/Datum.php
+++ b/src/Entity/Datum.php
@@ -108,7 +108,7 @@ class Datum implements \Stringable
     private ?string $originalFilename = null;
 
     #[ORM\ManyToOne(targetEntity: ChoiceList::class)]
-    #[Groups(['datum:read'])]
+    #[Groups(['datum:read', 'datum:write'])]
     private ?ChoiceList $choiceList = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -45,7 +45,7 @@ class Field
     private ?string $type = null;
 
     #[ORM\ManyToOne(targetEntity: ChoiceList::class)]
-    #[Groups(['datum:read'])]
+    #[Groups(['field:read'])]
     private ?ChoiceList $choiceList = null;
 
     #[ORM\ManyToOne(targetEntity: Template::class, inversedBy: 'fields')]


### PR DESCRIPTION
There is what I believe to be a typo preventing the choiceList field from being returned when querying a template's fields. This
is needed to populate a new item's fields based on that collection's default template, if any of those fields are list fields.

In addition, API clients are currently not allowed to write the choiceList field of a datum. Without this, there is no way to create a datum of list type for an item via the API.