### PR TITLE
Automatically select user's prefered timezone

### DIFF
--- a/templates/App/Security/first_connection.html.twig
+++ b/templates/App/Security/first_connection.html.twig
@@ -29,4 +29,12 @@
             </div>
         </div>
     </div>
+    <script>
+        // Selects the user's timezone, as indicated by the browser
+        if (typeof Intl !== 'undefined') {
+            const timezoneSelect = document.getElementById('user_timezone');
+            timezoneSelect.value = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            timezoneSelect.dispatchEvent(new Event('change'));
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
This makes use of the Intl API ([which has pretty wide support](https://caniuse.com/mdn-javascript_builtins_intl_datetimeformat_resolvedoptions_computed_timezone)) to find the user's preferred timezone, and automatically select it during the first-time setup.

Since this was such a small change, i opted to open a PR directly instead of an issue so it's simpler