### PR TITLE
dev/Dockerfile: Add vim to image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN addgroup --gid "$PGID" "$USER" && \
     adduser --gecos '' --no-create-home --disabled-password --uid "$PUID" --gid "$PGID" "$USER" && \
 # Install some basics dependencies
     apt-get update && \
-    apt-get install -y curl lsb-release software-properties-common gnupg2 && \
+    apt-get install -y curl lsb-release software-properties-common gnupg2 vim && \
 # PHP
     add-apt-repository ppa:ondrej/php && \
 # Nodejs


### PR DESCRIPTION
Previously, users couldn't edit files inside the container, because there was no text editor available. Not all files (e.g. PHP/nginx configs) are accessible from the outside. Add VI-Improved editor so that it's possible to edit sources.

```
root@90a8e0479b9c:/var/www/koillection# vim
bash: vim: command not found
root@90a8e0479b9c:/var/www/koillection# nano
bash: nano: command not found
root@90a8e0479b9c:/var/www/koillection# vi
bash: vi: command not found
```