### PR TITLE
entrypoint/dev: Fix improper usage of dump-env

### DIFF
--- a/docker/entrypoint-dev.sh
+++ b/docker/entrypoint-dev.sh
@@ -28,8 +28,6 @@ echo "DB_VERSION=${DB_VERSION:-}" >> "/var/www/koillection/.env.local"
 
 echo "CORS_ALLOW_ORIGIN=${CORS_ALLOW_ORIGIN:-'^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'}" >> "/var/www/koillection/.env.local"
 
-composer dump-env ${APP_ENV:-dev}
-
 echo "session.cookie_secure=${HTTPS_ENABLED}" >> /etc/php/8.2/fpm/conf.d/php.ini
 echo "date.timezone=${PHP_TZ}" >> /etc/php/8.2/fpm/conf.d/php.ini
 echo "memory_limit=${PHP_MEMORY_LIMIT:-'512M'}" >> /etc/php/8.2/fpm/conf.d/php.ini
@@ -38,9 +36,12 @@ echo "upload_max_filesize=${UPLOAD_MAX_FILESIZE:-'100M'}" >> /etc/php/8.2/fpm/co
 echo "post_max_size=${UPLOAD_MAX_FILESIZE:-'100M'}" >> /etc/php/8.2/fpm/conf.d/php.ini
 sed -i "s/client_max_body_size 100M;/client_max_body_size ${UPLOAD_MAX_FILESIZE:-'100M'};/g" /etc/nginx/nginx.conf
 
-echo "**** Migrate the database ****"
+echo "**** Install dependencies ****"
 cd /var/www/koillection && \
 composer install
+composer dump-env ${APP_ENV:-dev}
+
+echo "**** Migrate the database ****"
 php bin/console doctrine:migration:migrate --no-interaction --allow-no-migration --env=prod
 
 echo "**** Create API keys ****"


### PR DESCRIPTION
dump-env is Symfony specific command and must be executed only after deps are installed.