### PR TITLE
Make whole dropdown menu items clickable

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1472,6 +1472,10 @@ html.loading:before {
     border-bottom: 1px solid #e0e0e0;
     line-height: 1.5rem;
     margin: 0;
+}
+
+.dropdown-menu a {
+    display: block;
     padding: 15px 35px 10px 20px;
 }
 


### PR DESCRIPTION
Hi!
I would like to propose a small change that in my opinion makes dropdown menus more convenient to use.

Unitl now, we could only click on a link in dropdown menu item block directly (on the blue area):
![Screenshot from 2023-11-13 17-13-03](https://github.com/benjaminjonard/koillection/assets/86925036/26daf33c-acf2-4de7-b03e-03483ce88766)
I made some small changes in styles to make it possible to click on the whole block area (the whole menu item - green area - is treated as a link now):
![Screenshot from 2023-11-13 17-14-07](https://github.com/benjaminjonard/koillection/assets/86925036/a62cec89-660a-4717-85e2-c95fd1547854)

The same applies e.g. in the dropdown menu when selecting a language.