### PR TITLE
feat: grayscale thumbnail on collection page when item is currently loaned

### DIFF
--- a/src/Entity/Loan.php
+++ b/src/Entity/Loan.php
@@ -133,4 +133,9 @@ class Loan
 
         return $this;
     }
+
+    public function isCurrentlyLoaned(): ?Bool
+    {
+        return is_null($this->returnedAt);
+    }
 }

--- a/templates/App/Collection/_items_grid.html.twig
+++ b/templates/App/Collection/_items_grid.html.twig
@@ -3,7 +3,8 @@
         <div data-filter-target="element" data-title="{{ item.name }}">
             <div class="collection-item element valign-wrapper">
                 <a href="{{ path('app_item_show'|applyContext, {'id': item.id}) }}">
-                    <img src="{{ asset(item.imageSmallThumbnail|default('build/images/default.png')) }}" loading="lazy" title="{{item.name}}">
+                    {% set itemCurrentlyLoaned = item.getLoans().last().isCurrentlyLoaned() %}
+                    <img src="{{ asset(item.imageSmallThumbnail|default('build/images/default.png')) }}" loading="lazy" title="{{item.name}}" {% if itemCurrentlyLoaned %} style="filter: grayscale(100%);"{% endif %}>
                     {% if displayConfiguration.showItemQuantities and item.quantity > 1 %}
                         <span class="tag chip">x{{ item.quantity }}</span>
                     {% endif %}

--- a/templates/App/Collection/_items_list.html.twig
+++ b/templates/App/Collection/_items_list.html.twig
@@ -50,7 +50,8 @@
                 <td>
                     <a class="table-link" href="{{ link }}"></a>
                     {% if item.imageSmallThumbnail %}
-                        <img src="{{ asset(item.imageSmallThumbnail) }}" loading="lazy">
+                    {% set itemCurrentlyLoaned = item.getLoans().last().isCurrentlyLoaned() %}
+                        <img src="{{ asset(item.imageSmallThumbnail) }}" loading="lazy"{% if itemCurrentlyLoaned %} style="filter: grayscale(100%);"{% endif %}>
                     {% endif %}
                 </td>
                 <td data-column="name">


### PR DESCRIPTION
👋 

Wanted to be able to tell immediately from the collection page if an item is loaned or not. This is probably not the greatest solution, but it gets the job done.

This grayscales the item when loaned. I don’t know if it has further implication on database load (maybe, maybe not). Maybe a filter would be a better idea overall.