### PR TITLE
Enable Dutch locale

### DIFF
--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,6 +1,6 @@
 framework:
     default_locale: '%default_locale%'
-    enabled_locales: ['en', 'fr', 'es', 'de', 'it', 'pl', 'pt', 'pt_BR', 'ru', 'zh']
+    enabled_locales: ['en', 'fr', 'es', 'de', 'it', 'nl', 'pl', 'pt', 'pt_BR', 'ru', 'zh']
     translator:
         paths:
             - '%kernel.project_dir%/translations/'


### PR DESCRIPTION
Dutch language can't be chosen in the configuration yet, although Crowdin translations are at 100%. I think this is all that's needed to enable it?