### PR TITLE
Add JSON_UNESCAPED_UNICODE to json_encode

### DIFF
--- a/src/Controller/Scraper/CollectionScraperController.php
+++ b/src/Controller/Scraper/CollectionScraperController.php
@@ -193,7 +193,7 @@ class CollectionScraperController extends AbstractController
 
         $slug = $slugger->slug($scraper->getName())->lower();
 
-        return new FileResponse([json_encode($data)], "collection-scrapper-{$slug}.json", headers: ['Content-Type' => 'application/json']);
+        return new FileResponse([json_encode($data, JSON_UNESCAPED_UNICODE)], "collection-scrapper-{$slug}.json", headers: ['Content-Type' => 'application/json']);
     }
 
     #[Route(path: '/scrapers/collection-scrapers/{id}', name: 'app_scraper_collection_show', methods: ['GET'])]

--- a/src/Controller/Scraper/ItemScraperController.php
+++ b/src/Controller/Scraper/ItemScraperController.php
@@ -193,7 +193,7 @@ class ItemScraperController extends AbstractController
 
         $slug = $slugger->slug($scraper->getName())->lower();
 
-        return new FileResponse([json_encode($data)], "item-scrapper-{$slug}.json", headers: ['Content-Type' => 'application/json']);
+        return new FileResponse([json_encode($data, JSON_UNESCAPED_UNICODE)], "item-scrapper-{$slug}.json", headers: ['Content-Type' => 'application/json']);
     }
 
     #[Route(path: '/scrapers/item-scrapers/{id}', name: 'app_scraper_item_show', methods: ['GET'])]

--- a/src/Controller/Scraper/WishScraperController.php
+++ b/src/Controller/Scraper/WishScraperController.php
@@ -193,7 +193,7 @@ class WishScraperController extends AbstractController
 
         $slug = $slugger->slug($scraper->getName())->lower();
 
-        return new FileResponse([json_encode($data)], "wish-scrapper-{$slug}.json", headers: ['Content-Type' => 'application/json']);
+        return new FileResponse([json_encode($data, JSON_UNESCAPED_UNICODE)], "wish-scrapper-{$slug}.json", headers: ['Content-Type' => 'application/json']);
     }
 
     #[Route(path: '/scrapers/wish-scrapers/{id}', name: 'app_scraper_wish_show', methods: ['GET'])]


### PR DESCRIPTION
Ensure literal Unicode characters in exported XPath strings so that exporting and importing scrapers won't break XPath 1.0 parsing.