### PR TITLE
Added Bulk Actions (Duplicate, Move, Delete) to List View

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@
     <img src="https://img.shields.io/badge/mysql->=8.0-blue" />
 <p>
 
-# Koillection
+# Koillection (Bulk Actions Fork)
+
+*This is a customized fork of the original [Koillection](https://github.com/benjaminjonard/koillection) app. It has been specifically modified to make managing large collections easier and faster by introducing multi-selection and bulk editing tools.*
+
+### ✨ Custom Features Added to this Fork:
+* **Multi-Select List View:** Added checkboxes to the main item list view to select multiple items at once.
+* **Bulk Duplicate:** A new button to instantly clone one or multiple items (perfect for quickly adding similar items to your database!).
+* **Bulk Move:** A new dropdown menu and button to quickly move multiple selected items to a different collection.
+* **Bulk Delete:** A new button to permanently delete multiple items at once.
+
+---
 
 Koillection is a self-hosted collection manager created to keep track of physical (mostly) collections of any kind like books, DVDs, stamps, games... 
 Koillection is meant to be used for any kind of collections and doesn't come with pre-built metadata download. But you can tailor your own HTML scraper, or you can add your own metadata freely.
@@ -92,4 +102,4 @@ You are also welcome if you want to proofread existing translations.
 <!-- CROWDIN-TRANSLATIONS-PROGRESS-ACTION-END -->
 
 ## Licensing
-Koillection is an Open Source software, released under the MIT License. 
+Koillection is an Open Source software, released under the MIT License.

--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 class ItemController extends AbstractController
 {
@@ -67,7 +68,6 @@ class ItemController extends AbstractController
             }
         }
 
-        // Preload tags shared by all items in that collection
         $suggestedNames = [];
         if ($request->isMethod('GET')) {
             $item->setTags(new ArrayCollection($tagRepository->findRelatedToCollection($collection)));
@@ -197,5 +197,96 @@ class ItemController extends AbstractController
         }
 
         return new JsonResponse($data);
+    }
+
+    // ==========================================
+    // NEW BULK ACTION FEATURES
+    // ==========================================
+
+    #[Route('/items/bulk-duplicate', name: 'app_item_bulk_duplicate', methods: ['POST'])]
+    public function bulkDuplicate(Request $request, EntityManagerInterface $em, ItemRepository $itemRepository): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        $ids = $data['ids'] ?? [];
+        $debugLog = [];
+
+        foreach ($ids as $id) {
+            $item = $itemRepository->find($id);
+            if ($item) {
+                $newItem = clone $item;
+                $newItem->setName($item->getName() . ' (Copy)');
+                
+                $reflection = new \ReflectionClass($newItem);
+                $property = $reflection->getProperty('id');
+                $property->setAccessible(true);
+                $property->setValue($newItem, \Symfony\Component\Uid\Uuid::v4()->__toString());
+                
+                $em->persist($newItem);
+                $debugLog[] = "Successfully cloned item: " . $item->getName();
+            }
+        }
+
+        try {
+            $em->flush();
+            $debugLog[] = "Database save successful!";
+        } catch (\Exception $e) {
+            $debugLog[] = "DATABASE ERROR: " . $e->getMessage();
+        }
+
+        return new JsonResponse(['status' => 'ok', 'log' => $debugLog]);
+    }
+
+    #[Route('/items/bulk-delete', name: 'app_item_bulk_delete', methods: ['POST'])]
+    public function bulkDelete(Request $request, EntityManagerInterface $em, ItemRepository $itemRepository): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        $ids = $data['ids'] ?? [];
+
+        foreach ($ids as $id) {
+            $item = $itemRepository->find($id);
+            if ($item) {
+                $em->remove($item);
+            }
+        }
+        $em->flush();
+        return new JsonResponse(['status' => 'ok']);
+    }
+
+    // MAGIC FIX: Changed the URL to avoid the 404 Routing Collision!
+    #[Route('/items/custom/collections-list', name: 'app_collection_simple_list', methods: ['GET'])]
+    public function simpleCollectionList(CollectionRepository $collectionRepository): JsonResponse
+    {
+        $collections = $collectionRepository->findAll();
+        $data = [];
+        foreach ($collections as $collection) {
+            $data[] = [
+                'id' => (string) $collection->getId(),
+                'title' => (string) $collection->getTitle()
+            ];
+        }
+        return new JsonResponse($data);
+    }
+
+    #[Route('/items/bulk-move', name: 'app_item_bulk_move', methods: ['POST'])]
+    public function bulkMove(Request $request, EntityManagerInterface $em, ItemRepository $itemRepository, CollectionRepository $collectionRepository): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        $ids = $data['ids'] ?? [];
+        $targetId = $data['target_collection'] ?? null;
+
+        $targetCollection = $collectionRepository->find($targetId);
+        
+        if ($targetCollection) {
+            foreach ($ids as $id) {
+                $item = $itemRepository->find($id);
+                if ($item) {
+                    $item->setCollection($targetCollection);
+                    $em->persist($item);
+                }
+            }
+            $em->flush();
+        }
+
+        return new JsonResponse(['status' => 'ok']);
     }
 }

--- a/templates/App/Collection/_items_list.html.twig
+++ b/templates/App/Collection/_items_list.html.twig
@@ -1,9 +1,38 @@
 {% set sortingProperty = displayConfiguration.sortingProperty %}
 {% set sortingDirection = displayConfiguration.sortingDirection %}
 
+<!-- BULK ACTIONS BAR -->
+<div id="bulk-actions-bar" style="display: none; align-items: center; background-color: #26a69a; color: white; padding: 15px; border-radius: 4px; margin-bottom: 15px; box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14);">
+    <span style="font-size: 1.2em; margin-right: auto;">
+        <strong id="selected-count">0</strong> items selected
+    </span>
+    
+    <button type="button" id="btn-bulk-duplicate" class="btn waves-effect waves-light blue" style="margin-right: 10px;">
+        <i class="fa fa-copy fa-fw"></i> Duplicate
+    </button>
+    
+    <button type="button" id="btn-bulk-move" class="btn waves-effect waves-light orange" style="margin-right: 10px;">
+        <i class="fa fa-folder-open fa-fw"></i> Move
+    </button>
+
+    <select id="bulk-move-target" class="browser-default" style="display: block; width: 200px; margin-right: 10px; background: white; color: black; border-radius: 4px; padding: 5px; height: 36px; border: none;">
+        <option value="">Select destination...</option>
+    </select>
+    
+    <button type="button" id="btn-bulk-delete" class="btn waves-effect waves-light red">
+        <i class="fa fa-trash fa-fw"></i> Delete
+    </button>
+</div>
+
 <table class="highlight items-table" data-controller="table">
     <thead>
         <tr>
+            <th style="width: 40px; text-align: center;">
+                <label>
+                    <input type="checkbox" id="selectAllCheckboxes" />
+                    <span></span>
+                </label>
+            </th>
             <th></th>
             <th>
                 {{ 'label.name'|trans }}
@@ -47,6 +76,12 @@
         {% for item in items|naturalSorting(displayConfiguration) %}
             {% set link = path('app_item_show'|applyContext, {'id': item.id}) %}
             <tr class="list-element resize-element" data-title="{{ item.name }}" data-filter-target="element">
+                <td style="text-align: center; position: relative; z-index: 10;">
+                    <label>
+                        <input type="checkbox" class="item-checkbox" value="{{ item.id }}" />
+                        <span></span>
+                    </label>
+                </td>
                 <td>
                     <a class="table-link" href="{{ link }}"></a>
                     {% if item.imageSmallThumbnail %}
@@ -91,7 +126,7 @@
                         </td>
                     {% endif %}
                     {% if displayConfiguration.showActions %}
-                        <td class="table-actions center">
+                        <td class="table-actions center" style="position: relative; z-index: 10;">
                             <a href="{{ path('app_item_edit', {id: item.id}) }}" title="{{ 'tooltip.edit'|trans }}">
                                 <i class="fa fa-pencil fa-fw"></i>
                             </a>
@@ -106,3 +141,119 @@
         {% endfor %}
     </tbody>
 </table>
+
+<!-- JAVASCRIPT TO CONTROL CHECKBOXES -->
+<script>
+    setTimeout(function() {
+        const selectAllBox = document.getElementById('selectAllCheckboxes');
+        const itemBoxes = document.querySelectorAll('.item-checkbox');
+        const bulkBar = document.getElementById('bulk-actions-bar');
+        const countText = document.getElementById('selected-count');
+        const moveDropdown = document.getElementById('bulk-move-target');
+
+        // --- LOAD COLLECTIONS FOR DROPDOWN ---
+        if (moveDropdown) {
+            fetch('/items/custom/collections-list')
+                .then(response => response.json())
+                .then(collections => {
+                    collections.forEach(collection => {
+                        const option = document.createElement('option');
+                        option.value = collection.id;
+                        option.textContent = collection.title;
+                        moveDropdown.appendChild(option);
+                    });
+                })
+                .catch(error => {
+                    console.log("Dropdown failed to load: " + error);
+                    moveDropdown.innerHTML = '<option value="">Error loading collections</option>';
+                });
+        }
+
+        function updateBulkBar() {
+            const checkedBoxes = document.querySelectorAll('.item-checkbox:checked');
+            if (checkedBoxes.length > 0) {
+                bulkBar.style.display = 'flex';
+                countText.innerText = checkedBoxes.length;
+            } else {
+                bulkBar.style.display = 'none';
+            }
+        }
+
+        if (selectAllBox) {
+            selectAllBox.addEventListener('change', function() {
+                itemBoxes.forEach(box => {
+                    box.checked = selectAllBox.checked;
+                });
+                updateBulkBar();
+            });
+        }
+
+        itemBoxes.forEach(box => {
+            box.addEventListener('change', updateBulkBar);
+        });
+
+        // --- DUPLICATE BUTTON LOGIC ---
+        const btnDuplicate = document.getElementById('btn-bulk-duplicate');
+        if (btnDuplicate) {
+            btnDuplicate.addEventListener('click', function(e) {
+                e.preventDefault(); 
+                const checkedBoxes = document.querySelectorAll('.item-checkbox:checked');
+                const ids = Array.from(checkedBoxes).map(box => box.value);
+
+                if (confirm('Are you sure you want to duplicate ' + ids.length + ' item(s)?')) {
+                    btnDuplicate.innerHTML = '<i class="fa fa-spinner fa-spin fa-fw"></i> Working...';
+                    fetch('/items/bulk-duplicate', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                        body: JSON.stringify({ ids: ids })
+                    }).then(() => window.location.reload());
+                }
+            });
+        }
+
+        // --- DELETE BUTTON LOGIC ---
+        const btnDelete = document.getElementById('btn-bulk-delete');
+        if (btnDelete) {
+            btnDelete.addEventListener('click', function(e) {
+                e.preventDefault(); 
+                const checkedBoxes = document.querySelectorAll('.item-checkbox:checked');
+                const ids = Array.from(checkedBoxes).map(box => box.value);
+
+                if (confirm('WARNING: Are you sure you want to permanently delete ' + ids.length + ' item(s)?')) {
+                    btnDelete.innerHTML = '<i class="fa fa-spinner fa-spin fa-fw"></i> Deleting...';
+                    fetch('/items/bulk-delete', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                        body: JSON.stringify({ ids: ids })
+                    }).then(() => window.location.reload());
+                }
+            });
+        }
+
+        // --- MOVE BUTTON LOGIC ---
+        const btnMove = document.getElementById('btn-bulk-move');
+        if (btnMove) {
+            btnMove.addEventListener('click', function(e) {
+                e.preventDefault(); 
+                
+                const targetId = moveDropdown.value;
+                if (!targetId) {
+                    alert('Please select a destination collection from the dropdown first!');
+                    return;
+                }
+
+                const checkedBoxes = document.querySelectorAll('.item-checkbox:checked');
+                const ids = Array.from(checkedBoxes).map(box => box.value);
+
+                if (confirm('Are you sure you want to move ' + ids.length + ' item(s)?')) {
+                    btnMove.innerHTML = '<i class="fa fa-spinner fa-spin fa-fw"></i> Moving...';
+                    fetch('/items/bulk-move', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                        body: JSON.stringify({ ids: ids, target_collection: targetId })
+                    }).then(() => window.location.reload());
+                }
+            });
+        }
+    }, 500);
+</script>


### PR DESCRIPTION
Hi! I really needed a way to manage multiple items at once, so I built a Bulk Actions bar for the List View.

Resolves #1547

Features included:
- Multi-select checkboxes on the _items_list.html.twig table.
- A hidden action bar that appears when items are selected.
- Duplicate: Clones selected items and appends "(Copy)" to the name, generating a new UUID.
- Move: Fetches a simple list of collections via a new endpoint and moves selected items to the chosen target.
- Delete: Removes selected items.

_Note: I am very new to programming! I got this fully functional as a proof-of-concept on my local Docker setup, but I know it might need some polish (like adding CSRF tokens, translations, or moving the JS into a Stimulus controller) to meet your production standards. Let me know what you think!_