### PR TITLE
fix: store Datum file uploads with a non-active extension

### DIFF
--- a/assets/fixtures/nyancat.html
+++ b/assets/fixtures/nyancat.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+<body>
+<script>document.body.dataset.xss = "1";</script>
+</body>
+</html>

--- a/src/Service/ImageHandler.php
+++ b/src/Service/ImageHandler.php
@@ -45,7 +45,7 @@ class ImageHandler
             }
 
             $generatedName = $this->randomStringGenerator->generate(20);
-            $extension = $file->guessExtension()  ?? 'png';
+            $extension = $attribute->getOriginalFilenamePathProperty() ? 'bin' : ($file->guessExtension() ?? 'png');
             $fileName = $generatedName . '.' . $extension;
             $file->move($absolutePath, $fileName);
 

--- a/tests/Api/Datum/DatumApiTest.php
+++ b/tests/Api/Datum/DatumApiTest.php
@@ -291,6 +291,32 @@ class DatumApiTest extends ApiTestCase
         $this->assertFileExists(json_decode($crawler->getContent(), true)['file']);
     }
 
+    public function test_post_datum_file_stores_html_as_bin(): void
+    {
+        // Arrange
+        $user = UserFactory::createOne();
+        $collection = CollectionFactory::createOne(['owner' => $user]);
+        $datum = DatumFactory::createOne(['collection' => $collection, 'owner' => $user]);
+        $uploadedFile = $this->createFile('html');
+
+        // Act
+        $crawler = $this->createClientWithCredentials($user)->request('POST', '/api/data/' . $datum->getId() . '/file', [
+            'headers' => ['Content-Type: multipart/form-data'],
+            'extra' => [
+                'files' => [
+                    'fileFile' => $uploadedFile,
+                ],
+            ],
+        ]);
+
+        // Assert
+        $this->assertResponseIsSuccessful();
+        $this->assertMatchesResourceItemJsonSchema(Datum::class);
+        $file = json_decode($crawler->getContent(), true)['file'];
+        $this->assertStringEndsWith('.bin', $file);
+        $this->assertFileExists($file);
+    }
+
     public function test_post_datum_video(): void
     {
         // Arrange


### PR DESCRIPTION
Prevents active HTML/SVG/XML/JS payloads from being served with an executable extension from `public/uploads`.

Datum file uploads are generic user files, so this keeps the feature working while storing the uploaded file with a `.bin` extension. The original filename is still preserved by the existing `download` attribute in the file link.

Changes:
- `ImageHandler` stores uploads with an `originalFilenamePathProperty` (Datum file fields) as `.bin` instead of `guessExtension()`.
- Regression test verifies an HTML upload is stored with a `.bin` path.